### PR TITLE
fix: VRCSDK version filtering is not working

### DIFF
--- a/Assets/InstallerSource/VrcGetCs/Mod.cs
+++ b/Assets/InstallerSource/VrcGetCs/Mod.cs
@@ -1060,8 +1060,8 @@ namespace Anatawa12.VrcGet
 
             switch (package.name())
             {
-                case "com.vrchat.avatars":
-                case "com.vrchat.worlds":
+                case "com.vrchat.avatars" when is_vrcsdk_for_2019(package.version()):
+                case "com.vrchat.worlds" when is_vrcsdk_for_2019(package.version()):
                 case "com.vrchat.base" when is_vrcsdk_for_2019(package.version()):
                     return unity.major() == 2019;
                 case "com.vrchat.core.vpm-resolver" when is_resolver_for_2019(package.version()):


### PR DESCRIPTION
Unity2019使用時、VRCSDKのバージョンのフィルタリングに誤りがありました。
（3.5.0以上のバージョンが含まれてしまう）

下記の条件でテストしています。

インストール済みパッケージ：
com.vrchat.avatars@3.1.13
com.vrchat.base@3.1.13

VPAIの設定ファイル：
{
  "vpmRepositories": [
    "https://suzuryg.github.io/vpm-repos/vpm.json",
    "https://vpm.nadena.dev/vpm.json"
  ],
  "vpmDependencies": {
    "jp.suzuryg.face-emo":  "^1.4.0",
    "nadena.dev.modular-avatar":  "^1.8.0"
  },
  "includePrerelease": false
}